### PR TITLE
Bracket indirect variable access to force precedence in form generation

### DIFF
--- a/src/views/layouts/form.blade.php
+++ b/src/views/layouts/form.blade.php
@@ -201,7 +201,7 @@
 								<span class="input-group-addon"><span class="{!! $with_prepend_icon !!}"></span></span>
 							@endif
 
-							{!! Form::$element_info['type']($element_name, $default_value, $attributes) !!}
+							{!! Form::{$element_info['type']}($element_name, $default_value, $attributes) !!}
 
 							@if ($with_append)
 								<span class="input-group-addon">{!! $element_info['append'] !!}</span>


### PR DESCRIPTION
I'm trying to get Station to run with Laravel 5.4 and PHP 7, and I found that the following change is required on the PHP 7 side.

http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect