### PR TITLE
fix file upload for IE11

### DIFF
--- a/public/js/base.form.js
+++ b/public/js/base.form.js
@@ -195,9 +195,9 @@ $(document).ready(function() {
 
 
         $('#station-fileupload-form').submit();
-
         $("#postiframe").load(function () {
-                $iframeContents = $("#postiframe").contents().find('*').first().text();
+            try {
+                $iframeContents = $("#postiframe")[0].contentWindow.document.body.innerText;
                 $results = $.parseJSON($iframeContents);
                 if ($results.success)
                 {
@@ -233,6 +233,9 @@ $(document).ready(function() {
                     $(this).remove();
                     scroll(0,0);
                 }
+            } catch (e) {
+                $(this).remove();
+            }
         });
     });
 

--- a/src/controllers/StationFileController.php
+++ b/src/controllers/StationFileController.php
@@ -205,7 +205,7 @@ class StationFileController extends BaseController {
 	{
 		// return an error response if no file is detected, this may be due to the fact that the file is too large.
 		if (!$this->request->hasFile('uploaded_file')) {
-			return Response::json(['success' => FALSE, 'reason' => 'No file uploaded or invalid file type.']);
+			return Response::make(json_encode(['success' => FALSE, 'reason' => 'No file uploaded or invalid file type.']));
 		}
 
 		$panel               = new Panel;
@@ -239,7 +239,7 @@ class StationFileController extends BaseController {
 			$bad_image = !$is_an_image || !in_array(strtolower($extension), $allowed_image_extensions);
 
 			if ($bad_file) {
-				return Response::json(['success' => FALSE, 'reason' => 'File is not a valid image.']);
+				return Response::make(json_encode(['success' => FALSE, 'reason' => 'File is not a valid image.']));
 			}
 
 			$allow_upsize    = isset($element['allow_upsize']) && $element['allow_upsize'];
@@ -258,7 +258,7 @@ class StationFileController extends BaseController {
 			$target_directory   = isset($element['directory']) ? $element['directory'] : '';
 
 			if ($bad_file) {
-				return Response::json(['success' => FALSE, 'reason' => 'Sorry, this file type is not allowed.']);
+				return Response::make(json_encode(['success' => FALSE, 'reason' => 'Sorry, this file type is not allowed.']));
 			}
 
 			$this->send_to_s3($new_file_name, $target_directory, $app_config, TRUE);
@@ -282,7 +282,7 @@ class StationFileController extends BaseController {
 			'complete_uri'  => $complete_uri,
 		];
 
-		return Response::json($response);
+		return Response::make(json_encode($response));
 	}
 
 	private function fetch_original($filename, $app_config){


### PR DESCRIPTION
This reverts some changes in #11. This replaces `Response::json` with `Response::make` and `json_encode` to return a response with a content type of `text/html`. This is done because when the `iframe` POST returns a content type of `application/json` for IE11 it results in the following behavior:
- causes the browser to ask if save/download the response or not
- due to the above, it the `$iframeContents` value will return an empty string which would cause `$.parseJSON` to throw a syntax error

By changing it back to return as a plain `text/html` it will work as it has previously. The only difference is keeping all the error handling that was implemented in the previous PR.